### PR TITLE
Remove curly brackets for array access

### DIFF
--- a/src/WSDLDocument.php
+++ b/src/WSDLDocument.php
@@ -425,7 +425,7 @@ class WSDLDocument extends DOMDocument
         $sValue = '';
         foreach (explode("\n", $sComment) as $sLine) {
             $sLine = trim($sLine, " *\t\r/");
-            if (strlen($sLine) > 0 && $sLine{0} == '@') {
+            if (strlen($sLine) > 0 && $sLine[0] == '@') {
                 break;
             }
             $sValue .= ' ' . $sLine;


### PR DESCRIPTION
Prior to PHP 8.0.0, square brackets and curly braces could be used interchangeably for accessing array elements.
The curly brace syntax was deprecated as of PHP 7.4.0 and no longer supported as of PHP 8.0.0.